### PR TITLE
locks docker base image to node 10 to fix build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM node:alpine
+FROM node:10-alpine
 
 WORKDIR /work
 RUN apk update && \


### PR DESCRIPTION
Needed for https://github.com/hCaptcha/eth-kvstore/pull/25 and https://github.com/hCaptcha/eth-kvstore/pull/26